### PR TITLE
#165595240 Return All Users to Staff or Admin

### DIFF
--- a/server/controllers/user.js
+++ b/server/controllers/user.js
@@ -17,6 +17,12 @@ class User {
   static async getUsers(request, response) {
     try {
       const { rows } = await db.query('SELECT * FROM users;');
+      if (!request.user.isadmin) {
+        return response.status(401).json({
+          status: 401,
+          error: 'you do not have permission to perform that operation',
+        });
+      }
 
       return response.status(200).json({
         status: 200,

--- a/server/routes/user.js
+++ b/server/routes/user.js
@@ -3,10 +3,11 @@ import user from '../controllers/user';
 import signUpValidator from '../middleware/validators/signUpValidator';
 import signInValidator from '../middleware/validators/signInValidator';
 import userMidware from '../middleware/userMidware';
+import auth from '../helpers/auth';
 
 const userRouter = express.Router();
 
-userRouter.get('/users', user.getUsers);
+userRouter.get('/users', auth, user.getUsers);
 userRouter.post('/auth/signup', signUpValidator, userMidware.isClientOrStaff, user.signUp);
 userRouter.post('/auth/signin', signInValidator, user.signIn);
 

--- a/server/test/accountsTest.js
+++ b/server/test/accountsTest.js
@@ -156,4 +156,17 @@ describe('Accounts', () => {
       expect(response.body.error).to.equal('cannot find that account');
     });
   });
+
+  describe('get all users', () => {
+    it('return all users', async () => {
+      const loginResponse = await server.post('/api/v1/auth/signin')
+        .send(login);
+      const { token } = loginResponse.body.data[0];
+      const response = await server
+        .get('/api/v1/users')
+        .set('x-access-token', token);
+      expect(response.status).to.equal(200);
+      expect(response.body).to.be.an('object');
+    });
+  });
 });

--- a/server/test/usersTest.js
+++ b/server/test/usersTest.js
@@ -32,7 +32,7 @@ describe('User', () => {
           firstName: 'Bukky',
           lastName: 'Abayomi',
           password: 'hello1234',
-          type: 'client',
+          type: 'staff',
         });
       expect(response.status).to.equal(201);
     });


### PR DESCRIPTION
#### What does this PR do?
- Returns all users to staff or admin

#### Description of Task to be completed?
- On existing GET users route, verify that the requester is an admin

#### How should this be manually tested?
- As an admin, make an API GET request to `localhost:3000/users
- All existing users should be returned

#### Any background context you want to provide?
- N/A

#### What are the relevant pivotal tracker stories?
- 165595240
- https://www.pivotaltracker.com/story/show/165595240